### PR TITLE
Fix: 로그인 관련 API 연동, store 흐름 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "locat-admin",
-  "version": "0.3.0-beta",
+  "version": "0.4.1-beta",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/login/LoginView.vue
+++ b/src/components/login/LoginView.vue
@@ -99,15 +99,18 @@ export default defineComponent({
         );
 
         if (response.data) {
-          auth.storeUserId(userId.value);
-          localStorage.setItem("accessToken", response.data.token.accessToken);
-          localStorage.setItem(
-            "refreshToken",
-            response.data.token.refreshToken
-          );
           if (response.data.isPasswordExpired) {
             auth.markPasswordAsExpired();
           } else {
+            auth.storeUserId(userId.value);
+            localStorage.setItem(
+              "accessToken",
+              response.data.token.accessToken
+            );
+            localStorage.setItem(
+              "refreshToken",
+              response.data.token.refreshToken
+            );
             auth.setIsLoggedIn(true);
           }
         }

--- a/src/components/login/LoginView.vue
+++ b/src/components/login/LoginView.vue
@@ -51,7 +51,7 @@
 <script lang="ts">
 import { defineComponent, onMounted, ref } from "vue";
 import FingerprintJS from "@fingerprintjs/fingerprintjs";
-import { request } from "@/utils/request-client";
+import { PUBLIC_API_KEY, request } from "@/utils/request-client";
 import { LoginResponse } from "@/types/admin/login-response";
 import { useAuth } from "@/store/auth";
 import { BaseResponse } from "@/types/common/response";
@@ -94,15 +94,16 @@ export default defineComponent({
             }),
             headers: {
               "Content-Type": "application/json",
+              "Locat-Api-Key": PUBLIC_API_KEY,
             },
           }
         );
 
         if (response.data) {
+          auth.storeUserId(userId.value);
           if (response.data.isPasswordExpired) {
             auth.markPasswordAsExpired();
           } else {
-            auth.storeUserId(userId.value);
             localStorage.setItem(
               "accessToken",
               response.data.token.accessToken

--- a/src/components/login/PasswordResetView.vue
+++ b/src/components/login/PasswordResetView.vue
@@ -75,7 +75,7 @@ export default defineComponent({
       request<{ success: boolean }>("/v1/admin/users/me/password", {
         method: "POST",
         data: JSON.stringify({
-          userId: auth.userId,
+          email: auth.userId,
           newPassword: newPassword.value,
         }),
         headers: {

--- a/src/components/server/ServerManageView.vue
+++ b/src/components/server/ServerManageView.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <v-card>
+    <v-card v-if="isSuperAdmin">
       <v-card-title class="d-flex align-center pa-4">
         <span class="text-h4 font-weight-bold">서버 상태 대시보드</span>
         <v-chip
@@ -44,6 +44,11 @@
         </v-row>
       </v-card-text>
     </v-card>
+    <v-card v-else class="text-center pa-6">
+      <v-icon size="48" color="error" class="mb-4">mdi-alert-circle</v-icon>
+      <div class="text-h5 mb-2">접근 권한 없음</div>
+      <div class="text-body-1">서버 상태 열람 권한이 없습니다.</div>
+    </v-card>
   </v-container>
 </template>
 
@@ -53,6 +58,7 @@ import { IHealth, IServerHealth } from "@/types/server/server-metric";
 import { PUBLIC_API_KEY, request } from "@/utils/request-client";
 import HealthComponentCard from "./HealthComponentCard.vue";
 import { getServerStatusColor } from "@/utils/color-utils";
+import { useAuth } from "@/store/auth";
 
 export default defineComponent({
   name: "ServerManageView",
@@ -60,9 +66,13 @@ export default defineComponent({
     HealthComponentCard,
   },
   setup() {
+    const auth = useAuth();
+    const isSuperAdmin = computed(() => auth.isSuperAdmin());
     const health = ref<IHealth | null>(null);
 
     const fetchHealthInfo = async () => {
+      if (!isSuperAdmin.value) return;
+
       try {
         health.value = await request<IHealth>("/actuator/health", {
           headers: {
@@ -88,13 +98,16 @@ export default defineComponent({
     }));
 
     onMounted(() => {
-      fetchHealthInfo();
+      if (isSuperAdmin.value) {
+        fetchHealthInfo();
+      }
     });
 
     return {
       health,
       getServerStatusColor,
       serverHealth,
+      isSuperAdmin,
     };
   },
 });

--- a/src/components/user/UserDetailView.vue
+++ b/src/components/user/UserDetailView.vue
@@ -245,7 +245,7 @@ import {
   getStatusTypeColor,
   getUserTypeColor,
 } from "@/utils/color-utils";
-import { parseJwt } from "@/utils/token-utils";
+import { useAuth } from "@/store/auth";
 
 export default defineComponent({
   name: "UserDetailView",
@@ -257,9 +257,7 @@ export default defineComponent({
   },
   emits: ["back"],
   setup(props, { emit }) {
-    const currentUserAuth = parseJwt(
-      localStorage.getItem("accessToken") || ""
-    ).auth;
+    const currentUserAuth = useAuth().getAuthority();
     const userDetail = ref<UserStatResponse | null>(null);
     const foundItemStat = ref<AdminUserFoundItemStatResponse | null>(null);
     const lostItemStat = ref<AdminUserLostItemStatResponse | null>(null);

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { isTokenValid } from "@/utils/token-utils";
+import { isTokenValid, parseJwt } from "@/utils/token-utils";
 
 export const useAuth = defineStore("auth", {
   state: () => ({
@@ -26,6 +26,14 @@ export const useAuth = defineStore("auth", {
     },
     storeUserId(userId: string) {
       this.userId = userId;
+    },
+    getAuthority() {
+      return (
+        parseJwt(localStorage.getItem("accessToken") as string).auth || "NONE"
+      );
+    },
+    isSuperAdmin() {
+      return this.getAuthority() === "SUPER_ADMIN";
     },
   },
 });

--- a/src/utils/color-utils.ts
+++ b/src/utils/color-utils.ts
@@ -1,10 +1,11 @@
 const COLOR_MAP = {
   oauth: {
-    KAKAO: "yellow darken-2",
+    KAKAO: "amber darken-3",
     APPLE: "black",
     default: "grey",
   },
   userType: {
+    SUPER_ADMIN: "red darken-1",
     ADMIN: "deep-purple darken-1",
     USER: "blue darken-1",
     default: "grey",


### PR DESCRIPTION
- Api-Key 필요한 부분에 적절하게 헤더 추가할 수 있도록 수정
- 이미 토큰이 저장되어 비밀번호 재설정 화면에서 새로고침 시, 비밀번호 재설정 없이 바로 화면으로 진입 가능하던 현상 수정
- 가입 구분 => `KAKAO` 색상 톤 조절